### PR TITLE
Update example to Beam 2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,33 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile('org.apache.beam:beam-sdks-java-core:2.0.0')
-            {
-                exclude group: 'com.google.guava'
-                exclude group: 'com.google.protobuf'
-                exclude(module: 'protobuf-lite')
-            }
-    compile(group: 'com.google.cloud.dataflow', name: 'google-cloud-dataflow-java-sdk-all', version: '2.0.0')
-            {
-                exclude group: 'com.google.guava'
-                exclude(module: 'protobuf-lite')
-            }
-    compile('org.apache.beam:beam-sdks-java-extensions-protobuf:2.0.0')
-    compile('org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.0.0')
-            {
-                exclude group: 'com.google.guava'
-                exclude(module: 'protobuf-lite')
-            }
-    compile('org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.0.0')
-            {
-                exclude group: 'com.google.guava'
-                exclude group: 'com.google.protobuf'
-                exclude(module: 'protobuf-lite')
-            }
-    compile('org.apache.beam:beam-sdks-java-io-common:2.0.0')
-    compile "com.google.protobuf:protobuf-java:3.3.1"
-    compile "com.google.protobuf:protobuf-java-util:3.3.1"
-    compile 'com.google.guava:guava:21.0'
+    compile 'com.google.cloud.dataflow:google-cloud-dataflow-java-sdk-all:2.3.0'
 
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 

--- a/src/main/java/backup/TableRefPartition.java
+++ b/src/main/java/backup/TableRefPartition.java
@@ -2,6 +2,8 @@ package backup;
 
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TimePartitioning;
+import com.google.common.base.MoreObjects;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
@@ -15,27 +17,43 @@ public class TableRefPartition implements SerializableFunction<ValueInSingleWind
     private final String datasetId;
     private final String pattern;
     private final String table;
+    private final String partitionType;
 
     public static TableRefPartition perDay(String projectId, String datasetId, String tablePrefix) {
-        return new TableRefPartition(projectId, datasetId, "yyyyMMdd", tablePrefix + "$");
+        return new TableRefPartition(projectId, datasetId, "yyyyMMdd", tablePrefix + "$", "DAY");
     }
 
-    private TableRefPartition(String projectId, String datasetId, String pattern, String table) {
+    private TableRefPartition(String projectId, String datasetId, String pattern, String table, String partitionType) {
         this.projectId = projectId;
         this.datasetId = datasetId;
         this.pattern = pattern;
         this.table = table;
+        this.partitionType = partitionType;
     }
 
     @Override
     public TableDestination apply(ValueInSingleWindow<TableRow> input) {
-        DateTimeFormatter partition = DateTimeFormat.forPattern(pattern).withZoneUTC();
+        final DateTimeFormatter partition = DateTimeFormat.forPattern(pattern).withZoneUTC();
 
-        TableReference reference = new TableReference();
+        final TimePartitioning timePartitioning = new TimePartitioning();
+        timePartitioning.setType(this.partitionType);
+
+        final TableReference reference = new TableReference();
         reference.setProjectId(this.projectId);
         reference.setDatasetId(this.datasetId);
 
         reference.setTableId(table + input.getWindow().maxTimestamp().toString(partition));
-        return new TableDestination(reference, null);
+        return new TableDestination(reference, this.toString(), timePartitioning);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("projectId", projectId)
+                          .add("datasetId", datasetId)
+                          .add("pattern", pattern)
+                          .add("table", table)
+                          .add("partitionType", partitionType)
+                          .toString();
     }
 }


### PR DESCRIPTION
Hi Alex van Boxel,

I would like to thank you for the Medium blog that you've wrote. I've updated the example to make it work with Beam 2.3 and added table partitioning. Right now, when I try to execute the code, I get the following error:

```
java.lang.RuntimeException: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Cannot read partition information from a table that is not partitioned: our-google-project:aggregates.stream_view_counts$20180326",
    "reason" : "invalid"
  } ],
  "message" : "Cannot read partition information from a table that is not partitioned: our-google-project:aggregates.stream_view_counts$20180326",
  "status" : "INVALID_ARGUMENT"
}
        org.apache.beam.sdk.io.gcp.bigquery.BigQueryServicesImpl$DatasetServiceImpl.insertAll(BigQueryServicesImpl.java:773)
        org.apache.beam.sdk.io.gcp.bigquery.BigQueryServicesImpl$DatasetServiceImpl.insertAll(BigQueryServicesImpl.java:808)
        org.apache.beam.sdk.io.gcp.bigquery.StreamingWriteFn.flushRows(StreamingWriteFn.java:127)
        org.apache.beam.sdk.io.gcp.bigquery.StreamingWriteFn.finishBundle(StreamingWriteFn.java:97)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Cannot read partition information from a table that is not partitioned: our-google-project:aggregates.stream_view_counts$20180326",
    "reason" : "invalid"
  } ],
  "message" : "Cannot read partition information from a table that is not partitioned: our-google-project:aggregates.stream_view_counts$20180326",
  "status" : "INVALID_ARGUMENT"
}
        com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
        com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
        com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
        com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:321)
        com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1065)
        com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:419)
        com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
        com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:469)
        org.apache.beam.sdk.io.gcp.bigquery.BigQueryServicesImpl$DatasetServiceImpl.lambda$insertAll$0(BigQueryServicesImpl.java:720)
        java.util.concurrent.FutureTask.run(FutureTask.java:266)
        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        java.lang.Thread.run(Thread.java:745)
```

When adding the `TimePartitioning` to the definition, it works like a charm. When comparing the tables in the BigQuery UI, I can see that the partition is set to `DAY`.

It took me some time to figure this out, so I decided to create a PR to safe some time for other who are running into the same error.

Cheers, Fokko